### PR TITLE
fix gtk string localizations

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -23,6 +23,8 @@ layout:
     bind-file: $SNAP/etc/asound.conf
   /usr/share/alsa/alsa.conf:
     bind-file: $SNAP/usr/share/alsa/alsa.conf
+  /usr/share/locale-langpack:
+    bind: $SNAP/usr/share/locale-langpack
 
 apps:
   xournalpp:
@@ -150,6 +152,14 @@ parts:
       $TEXDIR/bin/*/tlmgr install $(cat $PKGLIST | tr '\n' ' ')
       # added additional packages
   
+  gtk-locales:
+    plugin: nil
+    build-snaps: [gnome-3-38-2004]
+    override-prime: |
+      set -eux
+      cp -R "/snap/gnome-3-38-2004/current/usr/share/locale-langpack" "$SNAPCRAFT_PRIME/usr/share/"
+
+
   # Find files provided by the base and platform snap and ensure they aren't
   # duplicated in this snap
   cleanup:


### PR DESCRIPTION
# Pull Request Template

## Description
Fixes the localizations of Gtk strings

Fixes #4

## Type of change

Please check only the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

**Test Configuration**:
- build the PR
- `snap run xournalpp`
- If the system language is English, go to menu `Edit > Preferences` and select a different language (say `de`) in the Languages panel. Restart Xournal++, so that the new language setting is applied.
- See that in menu `Hilfe` and menu `Bearbeiten` all menu entries are localized (in German language). So it's `Hilfe > Hilfe` and not `Hilfe > Help` for example (compare #4).
![grafik](https://user-images.githubusercontent.com/40485433/128981522-9e11c516-8f84-4b22-b2f9-930e583bd475.png)
![grafik](https://user-images.githubusercontent.com/40485433/128981647-9fb6db1c-2cdd-40d0-81de-497343f70d47.png)

* OS (please include version): Ubuntu 21.04

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

