### PR TITLE
Update to version 1.1.2

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -78,7 +78,7 @@ parts:
     after: [alsa]
     plugin: cmake
     source: https://github.com/xournalpp/xournalpp.git
-    source-tag: v1.1.1
+    source-tag: v1.1.2
     cmake-parameters:
       - "-DCMAKE_INSTALL_PREFIX=/usr"
     parse-info: [usr/share/metainfo/com.github.xournalpp.xournalpp.appdata.xml]
@@ -88,7 +88,7 @@ parts:
       snapcraftctl pull
       # workaround nightly tag being set
       #snapcraftctl set-version $(git describe --tags --abbrev=10)
-      snapcraftctl set-version 1.1.1
+      snapcraftctl set-version 1.1.2
 
     build-packages:
       - git


### PR DESCRIPTION
This is a minor bugfix update. No new dependencies are needed. See [upstream](https://github.com/xournalpp/xournalpp/releases/tag/v1.1.2).