### PR TITLE
Fix TEXMFVAR for tinytex

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -37,6 +37,7 @@ apps:
       # Make the bundled lua-lgi work
       LUA_PATH: $SNAP/usr/share/lua/5.3/?.lua
       LUA_CPATH: $SNAP/usr/lib/x86_64-linux-gnu/lua/5.3/?.so;$SNAP/usr/lib/aarch64-linux-gnu/lua/5.3/?.so
+      TEXMFVAR: $SNAP_USER_COMMON/.cache/texmf-var  # The default is not a writeable directory
 
     plugs:
       - alsa


### PR DESCRIPTION
# Pull Request Template

## Description

The `TEXMFVAR` environment variable is set to a writeable directory. LaTeX uses it to store cached runtime data. When the directory is non-writeable, the LaTeX tool doesn't produce valid PDF in some cases, for instance when using the `listings` package for typesetting programming code.

## Type of change

Please check only the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Built the snap locally and tested using the LaTeX formula:

```tex
$
\begin{lstlisting}
#include <iostream>
\end{lstlisting}
$
```
with a preamble that includes `\usepackage{listings}`.


**Test Configuration**:

* OS (please include version): Ubuntu 23.10
* Any other relevant environment information:

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

